### PR TITLE
Add kouworks

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -2478,6 +2478,13 @@
             "x_url": "https://x.com/n_randall"
           },
           {
+            "title": "kouworks",
+            "author": "Kou",
+            "site_url": "https://en.kou-works.jp",
+            "feed_url": "https://en.kou-works.jp/rss.xml",
+            "github_url": "https://github.com/hibinokou-spec"
+          },
+          {
             "title": "Kristaps Grinbergs’s Blog",
             "author": "Kristaps Grinbergs",
             "site_url": "https://kristaps.me",


### PR DESCRIPTION
Adds kouworks to the English "Development Blogs" category.

It's the English blog of a solo iOS developer based in Japan, writing mostly about on-device machine learning on Apple platforms (Core ML, Vision, and related APIs) alongside notes from shipping apps to the App Store.

- Site: https://en.kou-works.jp
- Feed: https://en.kou-works.jp/rss.xml

The entry is placed in alphabetical order and `blogs.json` still validates against `schema_blogs.json`.