### PR TITLE
Add Storefront Brief (English newsletter)

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -6052,6 +6052,12 @@
             "feed_url": "https://www.pixelpusher.club/feed"
           },
           {
+            "title": "Storefront Brief",
+            "author": "Fortune Insight, LLC",
+            "site_url": "https://fortune-insight.onrender.com/shop/",
+            "feed_url": "https://fortune-insight.onrender.com/shop/feed.xml"
+          },
+          {
             "title": "Swift Developments",
             "author": "Andy Bargh",
             "site_url": "https://andybargh.com/swiftdevelopments/",

--- a/blogs.json
+++ b/blogs.json
@@ -6055,7 +6055,7 @@
             "title": "Storefront Brief",
             "author": "Fortune Insight, LLC",
             "site_url": "https://fortune-insight.onrender.com/shop/",
-            "feed_url": "https://fortune-insight.onrender.com/shop/feed.xml"
+            "feed_url": "https://fortune-insight.onrender.com/shop/brief/feed.xml"
           },
           {
             "title": "Swift Developments",


### PR DESCRIPTION
Adds Storefront Brief to the English Newsletters category.

- Title: Storefront Brief
- Author: Fortune Insight, LLC
- Site: https://fortune-insight.onrender.com/shop/
- Feed: https://fortune-insight.onrender.com/shop/brief/feed.xml
- Sample: https://fortune-insight.onrender.com/shop/brief/issue-001-en.html

Weekly App Store policy and fee notes for indie iOS teams (EU / US / Asia). English Issue 1 covers Sonar ASO launch pricing through 31 Aug. Surgical +6 lines in blogs.json only (no file rewrite), placed alphabetically after Pixel Pushers.