### PR TITLE
Add Xtend Journal to Development Blogs

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -4819,6 +4819,14 @@
             "x_url": "https://x.com/XRealityZone"
           },
           {
+            "title": "Xtend Journal",
+            "author": "Mendy Aouizerat",
+            "site_url": "https://getxtend.com/blog/",
+            "feed_url": "https://getxtend.com/blog/feed.xml",
+            "github_url": "https://github.com/mendidou",
+            "linkedin_url": "https://www.linkedin.com/in/mendy-aouizerat/"
+          },
+          {
             "title": "Yaacoub",
             "author": "Peter Yaacoub",
             "site_url": "https://yaacoub.github.io/articles/",


### PR DESCRIPTION
Adding my blog to the Development Blogs category.

- Title: Xtend Journal
- Author: Mendy Aouizerat
- Site: https://getxtend.com/blog/
- Feed: https://getxtend.com/blog/feed.xml

I'm a solo iOS developer. The blog covers the parts of iOS and macOS
development that aren't documented anywhere: terminal emulation and PTYs
on iOS, UIKit input tricks for software keyboards, WebRTC as an app
transport, StoreKit server verification. Two posts are up so far, and it
publishes regularly.

Inserted in alphabetical order between XReality.Zone's Blog EN and
Yaacoub. JSON validated.