### PR TITLE
Add Silent Spice

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -4030,6 +4030,13 @@
             "x_url": "https://x.com/nakodark"
           },
           {
+            "title": "Silent Spice",
+            "author": "Lismond Bernard",
+            "site_url": "https://silentspice.substack.com",
+            "feed_url": "https://silentspice.substack.com/feed",
+            "github_url": "https://github.com/lismondbernard"
+          },
+          {
             "title": "Simon Fairbairn’s Blog",
             "author": "Simon Fairbairn",
             "site_url": "https://simonfairbairn.com/tag/swift/",


### PR DESCRIPTION
Adds Silent Spice (silentspice.substack.com) to Development Blogs.

Notes from a one-person iOS studio; the current series walks an open source app's git history as a TDD course (https://github.com/lismondbernard/etude). Feed is Substack's standard RSS with titles, canonical URLs, dates, and author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnWFa24vdEoFatAHsGn4Xs