### PR TITLE
Add Sensitivity Apple privacy engineering feed

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -3986,6 +3986,13 @@
             "x_url": "https://x.com/sebastianroehl"
           },
           {
+            "title": "Sensitivity Apple Privacy Engineering Notes",
+            "author": "Dmytro Polianskyi",
+            "site_url": "https://sensitivityscan.com/learn",
+            "feed_url": "https://sensitivityscan.com/developer-feed.xml",
+            "github_url": "https://github.com/MityaPolianskii"
+          },
+          {
             "title": "Serhii Kharauzov on Medium",
             "author": "Serhii Kharauzov",
             "site_url": "https://medium.com/@sergkharauzov",


### PR DESCRIPTION
## Summary

Adds a filtered RSS feed for Sensitivity Apple Privacy Engineering Notes to the English Development Blogs section.

The feed contains only Apple-platform engineering articles from the broader Sensitivity guide library. It currently covers on-device photo scanning architecture and false-positive handling.

Disclosure: I am the developer and owner of Sensitivity.

## Validation

- `jq empty blogs.json`
- `git diff --check`
- Site, feed, and GitHub profile URLs return HTTP 200
- Feed validates as RSS 2.0