### PR TITLE
Add Martin Grüner’s Blog

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -5153,6 +5153,15 @@
             "x_url": "https://x.com/jcieplinski"
           },
           {
+            "title": "Martin Grüner’s Blog",
+            "author": "Martin Grüner",
+            "site_url": "https://martingruner.com/blog",
+            "feed_url": "https://martingruner.com/feed.xml",
+            "bluesky_url": "https://bsky.app/profile/grunersoftware.bsky.social",
+            "x_url": "https://x.com/grunersoftware",
+            "github_url": "https://github.com/MartinGryner"
+          },
+          {
             "title": "Mobile Ad.ventures",
             "author": "Thomas Petit",
             "site_url": "https://madv.substack.com/",


### PR DESCRIPTION
Adds Martin Grüner’s Blog to the Marketing and Business Blogs section.

The RSS feed publishes Apple-platform content about App Store screenshot requirements, screenshot production and localisation workflows, release tooling, and lessons from shipping independent apps.

- Site: https://martingruner.com/blog
- RSS: https://martingruner.com/feed.xml

I am the author of the blog.