### PR TITLE
Add FeedsBar engineering (Company Blogs)

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -5831,7 +5831,7 @@
           {
             "title": "FeedsBar engineering",
             "author": "Graeme Chard",
-            "site_url": "https://feeds.bar/",
+            "site_url": "https://feeds.bar/writing/",
             "feed_url": "https://feeds.bar/feed.xml"
           }
         ]

--- a/blogs.json
+++ b/blogs.json
@@ -5827,6 +5827,12 @@
             "author": "Babs",
             "site_url": "https://verycuriousengineer.substack.com",
             "feed_url": "https://verycuriousengineer.substack.com/feed"
+          },
+          {
+            "title": "FeedsBar engineering",
+            "author": "Graeme Chard",
+            "site_url": "https://feeds.bar/",
+            "feed_url": "https://feeds.bar/feed.xml"
           }
         ]
       },


### PR DESCRIPTION
Adds FeedsBar's engineering writing under Company Blogs.

FeedsBar is a macOS app (Swift, SwiftUI, AppKit) and the site's writing is Apple-platform development content: for example, why Developer ID apps need an embedded provisioning profile for App Services (ShazamKit), the two xcodebuild flags that fix it, and the zsh builtin that faked the logs: https://feeds.bar/engineering/shazamkit-provisioning/

Feed: https://feeds.bar/feed.xml (Atom). Disclosure: I'm the author.