### PR TITLE
Add Manzanita Blog to English Company Blogs

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -5557,6 +5557,13 @@
             "x_url": "https://x.com/lickability"
           },
           {
+            "title": "Manzanita Blog",
+            "author": "Manzanita",
+            "site_url": "https://manzanita.run/blog/",
+            "feed_url": "https://manzanita.run/blog/rss.xml",
+            "github_url": "https://github.com/secondloop"
+          },
+          {
             "title": "MartianCraft: The Syndicate",
             "author": "MartianCraft Team",
             "site_url": "https://martiancraft.com/blog/",


### PR DESCRIPTION
Adds the Manzanita engineering blog under English → Company Blogs (alphabetically, after Lickability).

- Site: https://manzanita.run/blog/
- Feed: https://manzanita.run/blog/rss.xml
- Focus: macOS and iOS CI on GitHub Actions — benchmarks and engineering notes, the same category as the existing Bitrise Blog entry.

Disclosure: I work on Manzanita. The blog is technical (for example, a benchmark of five public iOS/macOS projects with a link to every public Actions run), not marketing. Happy to adjust the category or wording.