### PR TITLE
Add Edilec Product Engineering to company blogs

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -5399,6 +5399,11 @@
             "x_url": "https://x.com/detailsproapp"
           },
           {
+            "title": "Edilec Product Engineering",
+            "author": "Edilec Research",
+            "site_url": "https://edilec.com/blog/topics/product-engineering/"
+          },
+          {
             "title": "Emerge Tools' Blog",
             "author": "Noah Martin",
             "site_url": "https://www.emergetools.com/blog",


### PR DESCRIPTION
Adds Edilec Product Engineering to English → Company Blogs. Edilec Research is the institutional byline; the publication covers mobile engineering alongside broader product topics. Apple-platform examples include [Universal Links and Android App Links Across Every Install State](https://edilec.com/blog/proeng-11016/universal-links-android-app-links-install-states/) and [Mobile SDK Governance for Privacy, Data Collection, and Supply-Chain Risk](https://edilec.com/blog/proeng-11017/mobile-sdk-governance-privacy-manifests-supply-chain/).

Disclosure: submitted on behalf of Edilec. This contribution and the linked institutional guides were prepared with AI assistance. The guides are general engineering material referencing public platform documentation; they do not claim customer results or firsthand case studies. The entry contains only the publication title, author and existing topic URL; no topic-specific RSS feed is claimed.

Validation: `bundle exec rake validate:json` passes. The new record follows Company Blogs' existing title order, is the sole semantic change, and its destination returns HTTP 200 with a matching canonical. An open-and-closed PR and current-directory search found no Edilec entry before this submission.
