### PR TITLE
Add AppDrift Blog to Marketing and Business Blogs

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -5124,6 +5124,12 @@
         "description": "All of the Apple platform business and marketing related blogs. Articles on pricing experiments, ASO, reviews, ratings, case studies etc.",
         "sites": [
           {
+            "title": "AppDrift Blog",
+            "author": "AppDrift",
+            "site_url": "https://appdrift.co/blog",
+            "feed_url": "https://appdrift.co/feed.xml"
+          },
+          {
             "title": "Appfigures Resources",
             "author": "Appfigures Team",
             "site_url": "https://appfigures.com/resources",


### PR DESCRIPTION
Adds AppDrift Blog to English Marketing and Business Blogs. The blog covers App Store optimization, screenshot design, listing localization and original app-store research. I am the founder of AppDrift.

The site and RSS feed return HTTP 200 without redirects. The feed contains 97 articles with author information. The entry passes the repository JSON schema, and no existing AppDrift entry or open submission was found.
